### PR TITLE
Implement Elog; add a Texter interface

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	 "9fans.net/go/draw"
+	"9fans.net/go/draw"
 	"github.com/ProjectSerenity/acme/frame"
 	"image"
 )
@@ -59,9 +59,9 @@ func main() {
 	img, err := display.AllocImage(image.Rect(0, 0, 1024, 720), draw.RGB16, true, draw.Cyan)
 	if err != nil {
 		panic(err)
-	} 
+	}
 	f := frame.NewFrame(image.Rect(0, 0, 500, 600), display.DefaultFont, img, cols)
-	
+
 	for {
 		f.Tick(image.ZP, true)
 	}

--- a/buf_test.go
+++ b/buf_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBuf(t *testing.T) {
+}

--- a/dat.go
+++ b/dat.go
@@ -30,12 +30,12 @@ const (
 	QWxdata
 	QMAX
 
-//	Blockincr = 256
-//	MaxBlock  = 8 * 1024
-	NRange    = 10
-//	Infinity  = 0x7FFFFFFF
+	//	Blockincr = 256
+	//	MaxBlock  = 8 * 1024
+	NRange = 10
+	//	Infinity  = 0x7FFFFFFF
 
-//	STACK = 65536
+	//	STACK = 65536
 
 	Empty    = 0
 	Null     = '-'

--- a/disk.go
+++ b/disk.go
@@ -4,18 +4,16 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-//	"os/user"
+	//	"os/user"
 )
 
-
 const (
-	MaxBlock  = 8 * 1024	
+	MaxBlock  = 8 * 1024
 	Blockincr = 256
 )
 
-
 type Block struct {
-	addr uint   // disk address in bytes
+	addr uint // disk address in bytes
 
 	// NB: in the C version, these are in a union together. Only one is
 	// used at a time.
@@ -28,7 +26,7 @@ type Block struct {
 type Disk struct {
 	fd   *os.File
 	addr uint
-	free [MaxBlock/Blockincr + 1]*Block	// Block pointers bucketed by size.
+	free [MaxBlock/Blockincr + 1]*Block // Block pointers bucketed by size.
 }
 
 // NewDisk creates a new backing on-disk file for Acme's paging.
@@ -38,13 +36,12 @@ func NewDisk() *Disk {
 	if err != nil {
 		panic(err)
 	}
-	return &Disk {
+	return &Disk{
 		fd: tmp,
 	}
 }
 
-
-// ntosize computes the size of block to hold n bytes where n must be 
+// ntosize computes the size of block to hold n bytes where n must be
 // MaxBlock and the index into the bucket array. The 0-th bucket holds
 // only 0-length blocks.
 func ntosize(n uint) (uint, uint) {

--- a/disk_test.go
+++ b/disk_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-
 /*
 func TestNewBlock(t *testing.T) {
 
@@ -12,26 +11,25 @@ func TestNewBlock(t *testing.T) {
 	defer disk.fd.Name().Remove()
 
 
-	
+
 
 
 }
 */
 
-
 func TestNtosize(t *testing.T) {
 
 	testvector := []struct {
-		n uint
+		n  uint
 		sz uint
 		ip uint
 	}{
-		{ MaxBlock, MaxBlock, 32 },
-		{ 255, 256, 1 },
-		{ 1, 256, 1 },
-		{ 256, 256, 1 },
-		{ 257, 512, 2 },
-		{ 0, 0, 0 },
+		{MaxBlock, MaxBlock, 32},
+		{255, 256, 1},
+		{1, 256, 1},
+		{256, 256, 1},
+		{257, 512, 2},
+		{0, 0, 0},
 	}
 
 	for _, tv := range testvector {

--- a/elog.go
+++ b/elog.go
@@ -1,41 +1,243 @@
 package main
 
+import (
+	"fmt"
+)
+
 type ElogType byte
 
 const (
 	DeleteType ElogType = iota
 	InsertType
 	FilenameType
+	Wsequence = "warning: changes out of sequence\n"
 )
 
+/*
+ * Elog is a log of changes made by editing commands.  Three reasons for this:
+ * 1) We want addresses in commands to apply to old file, not file-in-change.
+ * 2) It's difficult to track changes correctly as things move, e.g. ,x m$
+ * 3) This gives an opportunity to optimize by merging adjacent changes.
+ * It's a little bit like the Undo/Redo log in Files, but Point 3) argues for a
+ * separate implementation.  To do this well, we use Replace as well as
+ * Insert and Delete
+ *
+ * There is a significant assumption that the log has increasing q0s.
+ * The log is then played back backwards to apply the changes to the text.
+ * Out-of-order edits are warned about.
+ */
 type Elog struct {
+	log    []ElogOperation
+	warned bool
+}
+
+type ElogOperation struct {
 	t  ElogType // Delete, Insert, Filename
 	q0 uint     // location of change (unused in f)
 	nd uint     // number of deleted characters
-	nr uint     // number of runes in string or filename
 	r  []rune
 }
 
-func (e *Elog) Term(f *File) {
-
+func MakeElog() Elog {
+	return Elog{[]ElogOperation{
+		ElogOperation{Null, 0, 0, []rune{}}, // Sentinel
+	}, false,
+	}
 }
 
-func (e *Elog) Close(f *File) {
-
+func (e *Elog) Reset() {
+	// TODO(flux): If working on large documents we may want to actually trim the
+	// array here, as it will hog memory after a fine-grained edit.  But don't worry about
+	// that until there's a memory issue.
+	(*e).log = (*e).log[0:1] // Just the sentinel
+	(*e).log[0].t = Null
 }
 
-func (e *Elog) Insert(f *File, q0 uint, r []rune) {
-
+func (e *Elog) Term() {
+	(*e).log = (*e).log[0:0]
+	(*e).warned = false
 }
 
-func (e *Elog) Delete(f *File, q0, q1 int) {
-
+func (e *ElogOperation) reset() {
+	e.t = Null
+	e.nd = 0
+	e.r = e.r[0:0]
 }
 
-func (e *Elog) Apply(f *File) {
+func elogclose(f *File) {}
 
+// Make sure buffer is large enough.  This could be simplified, but at the
+// cost of significant allocation churn.
+func (e *Elog) extend() {
+	// Slightly too clever code:  Double the slice if we're out,
+	// adding the reservation for the new eo
+	if cap((*e).log) == len((*e).log) {
+		t := make([]ElogOperation, len((*e).log), (cap((*e).log)+1)*2)
+		copy(t, (*e).log)
+		(*e).log = t
+	}
+	(*e).log = (*e).log[:len((*e).log)+1]
 }
 
-func (e *Elog) Replace(f *File, q0, q1 int, r []rune) {
+func (e *Elog) last() *ElogOperation {
+	return &((*e).log)[len((*e).log)-1]
+}
 
+func (e *Elog) secondlast() *ElogOperation {
+	return &((*e).log)[len((*e).log)-2]
+}
+
+func (eo *ElogOperation) setr(r []rune) {
+	if eo.r == nil || cap(eo.r) < len(r) {
+		eo.r = make([]rune, len(r), len(r))
+	} else {
+		eo.r = eo.r[0:len(r)]
+	}
+	copy(eo.r, r)
+}
+
+func (e *Elog) Replace(q0, q1 uint, r []rune) {
+	if q0 == q1 && len(r) == 0 {
+		return
+	}
+
+	eo := e.last()
+
+	// Check for out-of-order
+	if q0 < eo.q0 && !e.warned {
+		e.warned = true
+		warning(nil, Wsequence)
+	}
+
+	// TODO(flux): try to merge with previous
+
+	eo.t = Replace
+	eo.q0 = q0
+	eo.nd = q1 - q0
+	eo.setr(r)
+	if eo.q0 < e.secondlast().q0 {
+		panic("Changes not in order")
+	}
+}
+
+func (e *Elog) Insert(q0 uint, r []rune) {
+	if len(r) == 0 {
+		return
+	}
+
+	// This merge only works on the last item; I assume
+	// this is because the insertions at the same point tend
+	// to come together [logic vaguely lifted from the C implementation]
+	eo := e.last()
+
+	// Check for out-of-order
+	if (q0 < eo.q0) && !e.warned {
+		e.warned = true
+		warning(nil, Wsequence)
+	}
+
+	if eo.t == Insert && q0 == eo.q0 {
+		eo.r = append(eo.r, r...)
+		return
+	}
+
+	e.extend()
+
+	eo = e.last()
+	eo.t = Insert
+	eo.q0 = q0
+	eo.nd = 0
+	eo.setr(r)
+
+	if eo.q0 < e.secondlast().q0 {
+		panic("Changes not in order")
+	}
+}
+
+func (e *Elog) Delete(q0, q1 uint) {
+	if q0 == q1 {
+		return
+	}
+
+	// Try to merge deletes
+	eo := e.last()
+
+	// Check for out-of-order
+	if (q0 < eo.q0+eo.nd) && !e.warned {
+		e.warned = true
+		warning(nil, Wsequence)
+	}
+
+	if eo.t == Delete && (eo.q0+eo.nd == q0) {
+		eo.nd += q1 - q0
+		return
+	}
+
+	e.extend()
+
+	eo = e.last()
+	eo.t = Delete
+	eo.q0 = q0
+	eo.nd = q1 - q0
+	if eo.q0 < e.secondlast().q0 {
+		panic("Changes not in order")
+	}
+}
+
+const tracelog = true
+
+// Apply plays back the log, from back to front onto the given text.
+// Unlike the C version, this does not mark the file - that should happen at a higher
+// level.
+func (e *Elog) Apply(t Texter) {
+	/*
+		if len((*e).log) > 1 {
+			f.Mark() // TODO(flux): I think this is equivalent to checking inside
+					// the individual cases (as in the C code), since there's only modifications in the
+					// elog.
+		} else {
+			panic("Really?  Let's try not applying empty logs")
+		}
+	*/
+
+	// Will this always make a copy, or will the compiler turn
+	// the read-only accesses into an in-place read?
+
+	// The log is applied back-to-front - this avoids disturbing the text ahead of the
+	// current application point.
+	for i := len((*e).log) - 1; i >= 1; i-- {
+		eo := (*e).log[i]
+		switch eo.t {
+		case Replace:
+			if tracelog {
+				fmt.Printf("elog replace %d %d (%d %d)\n",
+					eo.q0, eo.q0+eo.nd, t.Q0(), t.Q1())
+			}
+			tq0, tq1 := t.Constrain(eo.q0, eo.q0+eo.nd)
+			t.Delete(tq0, tq1, true)
+			t.Insert(tq0, eo.r, true)
+			// Mark selection
+			if t.Q0() == eo.q0 && t.Q1() == eo.q0 {
+				t.SetQ1(t.Q1() + uint(len(eo.r)))
+			}
+		case Insert:
+			if tracelog {
+				fmt.Printf("elog insert %d %d (%d %d)\n",
+					eo.q0, eo.q0+uint(len(eo.r)), t.Q0(), t.Q1())
+			}
+			tq0, _ := t.Constrain(eo.q0, eo.q0)
+			t.Insert(tq0, eo.r, true)
+			if t.Q0() == eo.q0 && t.Q1() == eo.q0 {
+				t.SetQ1(t.Q1() + uint(len(eo.r)))
+			}
+		case Delete:
+			if tracelog {
+				fmt.Printf("elog delete %d %d (%d %d)\n",
+					eo.q0, eo.q0+uint(len(eo.r)), t.Q0(), t.Q1())
+			}
+			tq0, tq1 := t.Constrain(eo.q0, eo.q0+eo.nd)
+			t.Delete(tq0, tq1, true)
+		}
+	}
+	(*e).Term()
 }

--- a/elog_test.go
+++ b/elog_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestText implements texter for elog tests.
+type TextMock struct {
+	q0, q1 uint
+	buf    []rune
+}
+
+func (t TextMock) Constrain(q0, q1 uint) (p0, p1 uint) {
+	p0 = minu(q0, uint(len(t.buf)))
+	p1 = minu(q1, uint(len(t.buf)))
+	return p0, p1
+}
+
+func (t *TextMock) Delete(q0, q1 uint, tofile bool) {
+	_ = tofile
+	if q0 > uint(len(t.buf)) || q1 > uint(len(t.buf)) {
+		panic("Out-of-range Delete")
+	}
+	copy(t.buf[q0:], t.buf[q1:])
+	t.buf = t.buf[:uint(len(t.buf))-(q1-q0)] // Reslice to length
+}
+
+// Let's make sure our test fixture has the right form.
+func TestDelete(t *testing.T) {
+	tab := []struct {
+		q0, q1   uint
+		tb       TextMock
+		expected string
+	}{
+		{0, 5, TextMock{0, 0, []rune("0123456789")}, "56789"},
+		{0, 0, TextMock{0, 0, []rune("0123456789")}, "0123456789"},
+		{0, 10, TextMock{0, 0, []rune("0123456789")}, ""},
+		{1, 5, TextMock{0, 0, []rune("0123456789")}, "056789"},
+		{8, 10, TextMock{0, 0, []rune("0123456789")}, "01234567"},
+	}
+	for _, test := range tab {
+		tb := test.tb
+		tb.Delete(test.q0, test.q1, true)
+		if string(tb.buf) != test.expected {
+			t.Errorf("Delete Failed.  Expected %v, got %v", test.expected, string(tb.buf))
+		}
+	}
+}
+
+func (t *TextMock) Insert(q0 uint, r []rune, tofile bool) {
+	_ = tofile
+	if q0 > uint(len(t.buf)) {
+		panic("Out of range insertion")
+	}
+	t.buf = append(t.buf[:q0], append(r, t.buf[q0:]...)...)
+}
+
+func TestInsert(t *testing.T) {
+	tab := []struct {
+		q0       uint
+		tb       TextMock
+		insert   string
+		expected string
+	}{
+		{5, TextMock{0, 0, []rune("01234")}, "56789", "0123456789"},
+		{0, TextMock{0, 0, []rune("56789")}, "01234", "0123456789"},
+		{1, TextMock{0, 0, []rune("06789")}, "12345", "0123456789"},
+		{5, TextMock{0, 0, []rune("01234")}, "56789", "0123456789"},
+	}
+	for _, test := range tab {
+		tb := test.tb
+		tb.Insert(test.q0, []rune(test.insert), true)
+		if string(tb.buf) != test.expected {
+			t.Errorf("Insert Failed.  Expected %v, got %v", test.expected, string(tb.buf))
+		}
+	}
+}
+
+func (t *TextMock) Q0() uint      { return t.q0 }
+func (t *TextMock) SetQ0(q0 uint) { t.q0 = q0 }
+func (t *TextMock) Q1() uint      { return t.q1 }
+func (t *TextMock) SetQ1(q1 uint) { t.q1 = q1 }
+
+func TestElogInsertDelete(t *testing.T) {
+	t0 := []rune("This")
+	t1 := []rune(" is")
+	t2 := []rune(" a test")
+
+	e := MakeElog()
+
+	e.Insert(0, t0)
+	e.Insert(0, t1)
+	e.Insert(0, t2)
+
+	if len(e.log) != 2 {
+		t.Errorf("Insertions should have catenated")
+	}
+	if e.log[0].t != Null {
+		t.Errorf("Sentinel displaced")
+	}
+	if string(e.log[1].r) != "This is a test" {
+		t.Errorf("Failed to catenate properly")
+	}
+
+	e.Reset()
+	e.Insert(0, t0)
+	e.Insert(0, t1)
+	e.Insert(1, t2)
+	if len(e.log) != 3 {
+		t.Errorf("Expected 3 elements, have %d", len(e.log))
+	}
+	if string(e.log[1].r) != "This is" {
+		t.Errorf("Failed to catenate properly.  Expected 'This is', got '%s'", string(e.log[1].r))
+	}
+	if string(e.log[2].r) != " a test" {
+		t.Errorf("Failed to catenate properly")
+	}
+	e.Insert(1, t2)
+	if string(e.log[2].r) != " a test a test" {
+		t.Errorf("Failed to catenate properly.  Expected ' a test a test', got '%s'", string(e.log[1].r))
+	}
+
+	e.Delete(1, 5)
+	if len(e.log) != 4 {
+		t.Errorf("Expected 4 elements, have %d", len(e.log))
+	}
+	e.Delete(5, 5)
+	if len(e.log) != 4 {
+		fmt.Println(e)
+		t.Errorf("Expected 4 elements, have %d", len(e.log))
+	}
+}
+
+func TestApply(t *testing.T) {
+	tab := []struct {
+		tb       TextMock
+		elog     Elog
+		expected string
+	}{
+		{TextMock{0, 0, []rune{}},
+			Elog{[]ElogOperation{
+				{Null, 0, 0, []rune{}},
+				{Insert, 0, 0, []rune("0123456789")},
+			}, false},
+			"0123456789"},
+
+		{TextMock{0, 0, []rune("0123456789")},
+			Elog{[]ElogOperation{
+				{Null, 0, 0, []rune{}},
+				{Delete, 0, 5, []rune{}},
+			}, false},
+			"56789"},
+
+		{TextMock{0, 0, []rune("XXX56789")},
+			Elog{[]ElogOperation{
+				{Null, 0, 0, []rune{}},
+				{Insert, 0, 0, []rune("01234")},
+				{Delete, 0, 3, []rune{}},
+			}, false},
+			"0123456789"},
+
+		{TextMock{0, 0, []rune("XXX56789")},
+			Elog{[]ElogOperation{
+				{Null, 0, 0, []rune{}},
+				{Replace, 0, 3, []rune("01234")},
+			}, false},
+			"0123456789"},
+	}
+
+	for i, test := range tab {
+		tb := test.tb
+		test.elog.Apply(&tb)
+		if string(tb.buf) != test.expected {
+			t.Errorf("Apply Failed case %d: Expected %v, got %v", i, test.expected, string(tb.buf))
+		}
+	}
+}

--- a/text.go
+++ b/text.go
@@ -102,7 +102,7 @@ func (t *Text) BsInsert(q0 uint, r []rune, n uint, tofile bool, nrp *int) uint {
 	return 0
 }
 
-func (t *Text) Insert(q0 uint, r []rune, n uint, tofile bool) {
+func (t *Text) Insert(q0 uint, r []rune, tofile bool) {
 
 }
 
@@ -119,7 +119,8 @@ func (t *Text) Delete(q0, q1 uint, tofile bool) {
 }
 
 func (t *Text) Constrain(q0, q1 uint, p0, p1 *uint) {
-
+	*p0 = minu(q0, t.file.b.nc)
+	*p1 = minu(q1, t.file.b.nc)
 }
 
 func (t *Text) ReadRune(q uint) rune {

--- a/texter.go
+++ b/texter.go
@@ -1,0 +1,14 @@
+package main
+
+// Texter abstracts the buffering side of Text, allowing testing of Elog Apply
+// TODO(flux): This is probably lame and will get re-done when I understand
+// how Text stores its text.
+type Texter interface {
+	Constrain(q0, q1 uint) (p0, p1 uint)
+	Delete(q0, q1 uint, tofile bool)
+	Insert(q0 uint, r []rune, tofile bool)
+	Q0() uint // Selection start
+	SetQ0(uint)
+	Q1() uint // End of selelection
+	SetQ1(uint)
+}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,16 @@
 package main
 
+import (
+	"fmt"
+)
+
 func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func minu(a, b uint) uint {
 	if a < b {
 		return a
 	}
@@ -15,4 +25,11 @@ func region(a, b int) int {
 		return 0
 	}
 	return 1
+}
+
+type Mntdir string // TODO(flux): This will get implemented and conflict at some point :-)
+func warning(md *Mntdir, s string, args ...interface{}) {
+	// TODO(flux): Port to actually output to the error window
+	_ = md
+	fmt.Printf(s, args...)
 }


### PR DESCRIPTION
Uses a slice of ElogOperations instead of the typeless buffer
in the C version.  Forgoes all the flush logic in favor of managing
explicit additions.

Re-uses allocations as far as possible to avoid making garbage.

Does not coallesce Replace operations - they seem rare.  Can implement
if we need them.

Texter interface exposes the operations done on a Text from elog,
allowing implementation of a test harness.  Probably this object should
be called a "Selection Buffer", as it manages a Buffer with a Selection.

The TextMock implementation in elog_test.go is probably a fullish
buff.go implementation.

Also took advantage of the moment to run go fmt.